### PR TITLE
Make some properties of EasyFormData optional

### DIFF
--- a/src/data.interface.ts
+++ b/src/data.interface.ts
@@ -1,7 +1,7 @@
 export interface EasyFormData {
     questions: Question[]
-    settings: Settings
-    classes: Classes
+    settings?: Settings
+    classes?: Classes
 }
 
 export interface Question {
@@ -23,17 +23,17 @@ export interface Question {
 }
 
 export interface Settings {
-    submitButton: boolean
-    submitButtonText: string
-    submitButtonExtraValidation: boolean
-    singleErrorMessage: boolean
-    showValidation: boolean
-    errorOnDirty: boolean
+    submitButton?: boolean
+    submitButtonText?: string
+    submitButtonExtraValidation?: boolean
+    singleErrorMessage?: boolean
+    showValidation?: boolean
+    errorOnDirty?: boolean
 }
 
 export interface Classes {
-    form: string | Array<string>
-    submit: string | Array<string>
+    form?: string | Array<string>
+    submit?: string | Array<string>
 }
 
 export interface Validation {


### PR DESCRIPTION
I'd suggest to make options of EasyFormData required only if it really required in order to be able use EasyFormData as a type hint in code which uses easy-forms.
For example, in my application I define data for form:
`export let formData: EasyFormData = {
    questions: [...],
    ...
}`
in original version, if I use EasyFormData as a type hint, I had to define setiings and classes, though it is not really required for easy-forms.
